### PR TITLE
Redirect from old mesos ui location to new dcos mesos ui location

### DIFF
--- a/src/webui/master/static/js/controllers.js
+++ b/src/webui/master/static/js/controllers.js
@@ -188,6 +188,13 @@
   mesosApp.controller('MainCntl', [
       '$scope', '$http', '$location', '$timeout', '$modal',
       function($scope, $http, $location, $timeout, $modal) {
+
+    // Redirect from old mesos ui location to new dcos mesos ui location
+    if ($location.port() === 5050) {
+      var url = $location.protocol() + "://" + $location.host() + "/mesos";
+      window.location = url;
+    }
+
     $scope.doneLoading = true;
 
     // Adding bindings into scope so that they can be used from within


### PR DESCRIPTION
Now redirects from old mesos ui location (`:5050`) to new dcos mesos ui location (`/mesos`)