### PR TITLE
Changing agent_host to expect a relative path

### DIFF
--- a/src/webui/master/static/browse.html
+++ b/src/webui/master/static/browse.html
@@ -68,7 +68,7 @@
             </td>
             <td>
               <a data-ng-show="file.mode[0] != 'd'"
-                 href="//{{agent_host}}/files/download?path={{encodeURIComponent(file.path)}}">
+                 href="{{agent_host}}/files/download?path={{encodeURIComponent(file.path)}}">
                 <button class="btn btn-xs btn-default" type="button">
                   Download
                 </button>


### PR DESCRIPTION
agent_host is now a relative path and as such should not expect a full hostname.

Fixes the download problem on the browse pages for mesos ui:
![](https://cl.ly/0l1t1p2m3m1F/Image%202016-07-18%20at%2015.47.21.png)