### PR TITLE
[WIP] TLS: Add support for ECDH ciphers

### DIFF
--- a/3rdparty/libprocess/include/process/ssl/flags.hpp
+++ b/3rdparty/libprocess/include/process/ssl/flags.hpp
@@ -45,6 +45,7 @@ public:
   Option<std::string> ca_dir;
   Option<std::string> ca_file;
   std::string ciphers;
+  std::string ecdh_curve;
   bool enable_ssl_v3;
   bool enable_tls_v1_0;
   bool enable_tls_v1_1;

--- a/3rdparty/libprocess/src/openssl.cpp
+++ b/3rdparty/libprocess/src/openssl.cpp
@@ -593,6 +593,9 @@ void reinitialize()
   if (!ssl_flags->enable_tls_v1_2) { ssl_options |= SSL_OP_NO_TLSv1_2; }
 
   SSL_CTX_set_options(ctx, ssl_options);
+
+  // TODO(mh): Testing enabling auto curve selection
+  SSL_CTX_set_ecdh_auto(ctx, 1);
 }
 
 

--- a/3rdparty/libprocess/src/openssl.hpp
+++ b/3rdparty/libprocess/src/openssl.hpp
@@ -45,6 +45,7 @@ namespace openssl {
 //    LIBPROCESS_SSL_ENABLE_TLS_V1_0=(false|0,true|1)
 //    LIBPROCESS_SSL_ENABLE_TLS_V1_1=(false|0,true|1)
 //    LIBPROCESS_SSL_ENABLE_TLS_V1_2=(false|0,true|1)
+//    LIBPROCESS_SSL_ECDH_CURVE=(auto|preferred curve)
 //
 // TODO(benh): When/If we need to support multiple contexts in the
 // same process, for example for Server Name Indication (SNI), then

--- a/docs/ssl.md
+++ b/docs/ssl.md
@@ -74,6 +74,9 @@ The above switches enable / disable the specified protocols. By default only TLS
 _SSLv2 is disabled completely because modern versions of OpenSSL disable it using multiple compile time configuration options._
 #<a name="Dependencies"></a>Dependencies
 
+#### LIBPROCESS_SSL_ECDH_CURVE=(auto|name of ec curve) [default=auto]
+The name of elliptic curve that should be used for ECDHE based cipher suites. List of valid values depends on OpenSSL version. Default value `auto` leaves up to OpenSSL to pick curve in versions `1.1.0+` and uses `prime256v1` in versions `1.0.2` and lower. OpenSSL version `1.1.0` allows to specify multiple curves in format `prime256v1:secp384r1`.
+
 ### libevent
 We require the OpenSSL support from libevent. The suggested version of libevent is [`2.0.22-stable`](https://github.com/libevent/libevent/releases/tag/release-2.0.22-stable). As new releases come out we will try to maintain compatibility.
 


### PR DESCRIPTION
Code is mostly copied from NGINX implementation. The patch creates versioned dependency on openssl `0.9.8` and higher.

**NOT TESTED**