### PR TITLE
Expose hierarchical allocator recovery parameters as master flags

### DIFF
--- a/include/mesos/allocator/allocator.hpp
+++ b/include/mesos/allocator/allocator.hpp
@@ -66,6 +66,10 @@ struct Options
   size_t maxCompletedFrameworks = 0;
 
   bool publishPerFrameworkMetrics = true;
+
+  // Recovery options
+  Duration recoveryTimeout = Minutes(10);
+  float agentRecoveryFactor = 0.80;
 };
 
 
@@ -104,7 +108,6 @@ private:
 
   OfferConstraintsFilter(internal::OfferConstraintsFilterImpl&& impl_);
 };
-
 
 /**
  * Per-framework allocator-specific options that are not part of

--- a/src/master/allocator/mesos/hierarchical.hpp
+++ b/src/master/allocator/mesos/hierarchical.hpp
@@ -755,6 +755,8 @@ protected:
 
   // Recovery data.
   Option<int> expectedAgentCount;
+  float agentRecoveryFactor;
+  Duration recoveryTimeout;
 
   lambda::function<
       void(const FrameworkID&,

--- a/src/master/constants.hpp
+++ b/src/master/constants.hpp
@@ -48,6 +48,10 @@ constexpr double MIN_CPUS = 0.01;
 // Minimum amount of memory per offer.
 constexpr Bytes MIN_MEM = Megabytes(32);
 
+// Hierarchical allocator configuration
+constexpr Duration DEFAULT_RECOVERY_TIMEOUT = Minutes(10);
+constexpr float DEFAULT_AGENT_RECOVERY_FACTOR = 0.80;
+
 // Default timeout for v0 framework and agent authentication
 // before the master cancels an in-progress authentication.
 //

--- a/src/master/flags.cpp
+++ b/src/master/flags.cpp
@@ -460,6 +460,18 @@ mesos::internal::master::Flags::Flags()
       "load an alternate allocator module using `--modules`.",
       DEFAULT_ALLOCATOR);
 
+  add(&Flags::hierarchical_recovery_factor,
+      "hierarchical_recovery_factor",
+      "Ratio of minimal re-registred agent before sending\n"
+      "offers after a leader re-election",
+      DEFAULT_AGENT_RECOVERY_FACTOR);
+
+  add(&Flags::hierarchical_recovery_timeout,
+      "hierarchical_recovery_timeout",
+      "Maximum time to wait before sending offers after a leader\n"
+      "re-election.",
+      DEFAULT_RECOVERY_TIMEOUT);
+
   add(&Flags::fair_sharing_excluded_resource_names,
       "fair_sharing_excluded_resource_names",
       "A comma-separated list of the resource names (e.g. 'gpus')\n"

--- a/src/master/flags.hpp
+++ b/src/master/flags.hpp
@@ -81,6 +81,8 @@ public:
   Option<std::string> modulesDir;
   std::string authenticators;
   std::string allocator;
+  float hierarchical_recovery_factor;
+  Duration hierarchical_recovery_timeout;
   Option<std::set<std::string>> fair_sharing_excluded_resource_names;
   bool filter_gpu_resources;
   std::string min_allocatable_resources;

--- a/src/master/master.cpp
+++ b/src/master/master.cpp
@@ -789,6 +789,8 @@ void Master::initialize()
   options.minAllocatableResources = minAllocatableResources;
   options.maxCompletedFrameworks = flags.max_completed_frameworks;
   options.publishPerFrameworkMetrics = flags.publish_per_framework_metrics;
+  options.recoveryTimeout = flags.hierarchical_recovery_timeout;
+  options.agentRecoveryFactor = flags.hierarchical_recovery_factor;
 
   // Initialize the allocator.
   allocator->initialize(


### PR DESCRIPTION
Hello,

We needed to expose two parameters of the hierarchical allocator recovery options as master flags. Are you interested in such a PR?

It's rather simple but if you have any input on how I can improve it, don't hesitate.

Br